### PR TITLE
return 404 for missing tx_hash instead of 500 (NotFoundError)

### DIFF
--- a/demo/midgard-node/src/commands/listen.ts
+++ b/demo/midgard-node/src/commands/listen.ts
@@ -129,6 +129,24 @@ const handleGenericGetFailure = (
   e: SDK.Utils.GenericErrorFields,
 ) => failWith500("GET", endpoint, e.cause, e.message);
 
+const lookupTxCbor = (txHashBytes: Buffer, txHashParam: string) =>
+  MempoolDB.retrieveTxCborByHash(txHashBytes).pipe(
+    Effect.tap(() =>
+      Effect.logInfo(
+        `GET /${TX_ENDPOINT} - Transaction found in mempool: ${txHashParam}`,
+      ),
+    ),
+    Effect.catchTag("NotFoundError", () =>
+      ImmutableDB.retrieveTxCborByHash(txHashBytes).pipe(
+        Effect.tap(() =>
+          Effect.logInfo(
+            `GET /${TX_ENDPOINT} - Transaction found in ImmutableDB: ${txHashParam}`,
+          ),
+        ),
+      ),
+    ),
+  );
+
 const getTxHandler = Effect.gen(function* () {
   const params = yield* ParsedSearchParams;
   const txHashParam = params["tx_hash"];
@@ -145,27 +163,22 @@ const getTxHandler = Effect.gen(function* () {
       { status: 404 },
     );
   }
+
   const txHashBytes = Buffer.from(fromHex(txHashParam));
   yield* Effect.logInfo("txHashBytes", txHashBytes);
-  const foundCbor: Buffer = yield* MempoolDB.retrieveTxCborByHash(
-    txHashBytes,
-  ).pipe(
-    Effect.catchAll((_e) =>
-      Effect.gen(function* () {
-        const fromImmutable =
-          yield* ImmutableDB.retrieveTxCborByHash(txHashBytes);
-        yield* Effect.logInfo(
-          `GET /${TX_ENDPOINT} - Transaction found in ImmutableDB: ${txHashParam}`,
-        );
-        return fromImmutable;
-      }),
+
+  return yield* lookupTxCbor(txHashBytes, txHashParam).pipe(
+    Effect.tap((foundCbor) => Effect.logInfo("foundCbor", bufferToHex(foundCbor))),
+    Effect.flatMap((foundCbor) =>
+      HttpServerResponse.json({ tx: bufferToHex(foundCbor) }),
+    ),
+    Effect.catchTag("NotFoundError", () =>
+      HttpServerResponse.json(
+        { error: `Transaction not found: ${txHashParam}` },
+        { status: 404 },
+      ),
     ),
   );
-  yield* Effect.logInfo(
-    `GET /${TX_ENDPOINT} - Transaction found in mempool: ${txHashParam}`,
-  );
-  yield* Effect.logInfo("foundCbor", bufferToHex(foundCbor));
-  return yield* HttpServerResponse.json({ tx: bufferToHex(foundCbor) });
 }).pipe(
   Effect.catchTag("HttpBodyError", (e) => failWith500("GET", TX_ENDPOINT, e)),
   Effect.catchTag("DatabaseError", (e) => handleDBGetFailure(TX_ENDPOINT, e)),

--- a/demo/midgard-node/src/commands/listen.ts
+++ b/demo/midgard-node/src/commands/listen.ts
@@ -160,13 +160,11 @@ const getTxHandler = Effect.gen(function* () {
     );
     return yield* HttpServerResponse.json(
       { error: `Invalid transaction hash: ${txHashParam}` },
-      { status: 404 },
+      { status: 400 },
     );
   }
 
   const txHashBytes = Buffer.from(fromHex(txHashParam));
-  yield* Effect.logInfo("txHashBytes", txHashBytes);
-
   return yield* lookupTxCbor(txHashBytes, txHashParam).pipe(
     Effect.tap((foundCbor) => Effect.logInfo("foundCbor", bufferToHex(foundCbor))),
     Effect.flatMap((foundCbor) =>

--- a/demo/midgard-node/src/database/utils/common.ts
+++ b/demo/midgard-node/src/database/utils/common.ts
@@ -47,10 +47,7 @@ export class DatabaseError extends Data.TaggedError("DatabaseError")<
   SDK.Utils.GenericErrorFields & { readonly table: string }
 > {}
 
-export const NotFoundErrorTypeId = Symbol.for("@midgard/NotFoundError");
-
-export class NotFoundError extends TypeIdError(
-  NotFoundErrorTypeId,
+export class NotFoundError extends Data.TaggedError(
   "NotFoundError",
 )<SDK.Utils.GenericErrorFields & {
   readonly table: string;


### PR DESCRIPTION
`midgard-manager` checks node availability via `nodeClient.isAvailable` by calling the tx endpoint with a `tx_hash` that is effectively “empty” (hash of all `0`s). The node currently treats “no rows returned” as an SQL error and responds with **500**, which makes the availability check fail for the wrong reason.

### What changed

* Introduced a typed `NotFoundError` (`@midgard/NotFoundError`) in `database/utils/common.ts` using `TypeIdError`.
* Updated `database/utils/tx.ts`:

  * `retrieveValue()` now returns `NotFoundError` when the query result set is empty (`result.length === 0`) instead of surfacing an SQL error.
  * Error mapping preserves `NotFoundError` and wraps only real SQL errors into `DatabaseError`.
* Refactored `getTxHandler` in `commands/listen.ts`:

  * Extracted `lookupTxCbor()` to try mempool first, then fallback to ImmutableDB on `NotFoundError`.
  * If neither DB has the tx, the handler returns **404** with `Transaction not found: <hash>` (instead of bubbling into a 500).
  * Added more explicit logging around where the tx was found and the returned CBOR.

### Behavior change

* **Before:** missing tx hash (including the all-zero hash used by availability checks) could lead to **500** due to SQL error semantics.
* **After:** missing tx returns **404** (“not found”), while real DB/SQL failures still return **500**.

### Why this is correct

A missing transaction is an expected condition, not an internal server error. This aligns API behavior with `midgard-manager`’s availability probing and avoids false negatives caused by misclassified errors.

### Testing / verification

* Call `GET /tx?tx_hash=<valid 64-hex but not present>` → **404**
* Call `GET /tx?tx_hash=<present in mempool>` → **200**
* Call `GET /tx?tx_hash=<not in mempool but present in immutable>` → **200**
* Force DB connectivity failure → still **500** (unchanged for real failures)
